### PR TITLE
Use phthalocyanine green theme and polish layouts

### DIFF
--- a/WatchMeGo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/WatchMeGo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "0.518",
-          "red" : "0.039"
+          "blue" : "0.435",
+          "green" : "0.608",
+          "red" : "0.000"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "0.518",
-          "red" : "0.039"
+          "blue" : "0.435",
+          "green" : "0.608",
+          "red" : "0.000"
         }
       },
       "idiom" : "universal"

--- a/WatchMeGo/Assets.xcassets/ButtonPrimary.colorset/Contents.json
+++ b/WatchMeGo/Assets.xcassets/ButtonPrimary.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.447",
-          "green" : "0.545",
+          "blue" : "0.435",
+          "green" : "0.608",
           "red" : "0.000"
         }
       },
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.651",
-          "green" : "0.796",
-          "red" : "0.063"
+          "blue" : "0.435",
+          "green" : "0.608",
+          "red" : "0.000"
         }
       },
       "idiom" : "universal"

--- a/WatchMeGo/View/LoginView.swift
+++ b/WatchMeGo/View/LoginView.swift
@@ -41,7 +41,9 @@ struct LoginView: View {
             }
         }
         .padding(DesignSystem.Spacing.l)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(DesignSystem.Colors.background)
+        .ignoresSafeArea()
     }
 }
 

--- a/WatchMeGo/View/MainView.swift
+++ b/WatchMeGo/View/MainView.swift
@@ -12,16 +12,28 @@ struct MainView: View {
     @Bindable var coordinator: Coordinator
     
     var body: some View {
-        VStack(spacing: DesignSystem.Spacing.m) {
+        VStack(spacing: DesignSystem.Spacing.l) {
             if viewModel.isAuthorized {
-                ProgressBarView(label: "Calories", value: viewModel.calories, goal: 500, color: DesignSystem.Colors.move, iconName: "flame.fill")
-                ProgressBarView(label: "Exercise Minutes", value: viewModel.exerciseMinutes, goal: 80, color: DesignSystem.Colors.exercise, iconName: "figure.run")
-                ProgressBarView(label: "Stand Hours", value: viewModel.standHours, goal: 10, color: DesignSystem.Colors.stand, iconName: "clock")
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.m) {
+                    Text("\(coordinator.currentUser?.name ?? "Your") progress")
+                        .font(DesignSystem.Fonts.headline)
+                        .foregroundColor(DesignSystem.Colors.primary)
+
+                    ProgressBarView(label: "Calories", value: viewModel.calories, goal: 500, color: DesignSystem.Colors.move, iconName: "flame.fill")
+                    ProgressBarView(label: "Exercise Minutes", value: viewModel.exerciseMinutes, goal: 80, color: DesignSystem.Colors.exercise, iconName: "figure.run")
+                    ProgressBarView(label: "Stand Hours", value: viewModel.standHours, goal: 10, color: DesignSystem.Colors.stand, iconName: "clock")
+                }
 
                 if let competitive = viewModel.competitiveUser {
-                    ProgressBarView(label: "\(competitive.name)'s Calories", value: competitive.currentProgress?.calories ?? 0, goal: 500, color: DesignSystem.Colors.move, iconName: "flame.fill")
-                    ProgressBarView(label: "\(competitive.name)'s Exercise Minutes", value: competitive.currentProgress?.exerciseMinutes ?? 0, goal: 80, color: DesignSystem.Colors.exercise, iconName: "figure.run")
-                    ProgressBarView(label: "\(competitive.name)'s Stand Hours", value: competitive.currentProgress?.standHours ?? 0, goal: 10, color: DesignSystem.Colors.stand, iconName: "clock")
+                    VStack(alignment: .leading, spacing: DesignSystem.Spacing.m) {
+                        Text("\(competitive.name) progress")
+                            .font(DesignSystem.Fonts.headline)
+                            .foregroundColor(DesignSystem.Colors.primary)
+
+                        ProgressBarView(label: "Calories", value: competitive.currentProgress?.calories ?? 0, goal: 500, color: DesignSystem.Colors.move, iconName: "flame.fill")
+                        ProgressBarView(label: "Exercise Minutes", value: competitive.currentProgress?.exerciseMinutes ?? 0, goal: 80, color: DesignSystem.Colors.exercise, iconName: "figure.run")
+                        ProgressBarView(label: "Stand Hours", value: competitive.currentProgress?.standHours ?? 0, goal: 10, color: DesignSystem.Colors.stand, iconName: "clock")
+                    }
                 }
             } else {
                 Text("HealthKit access required or denied.")

--- a/WatchMeGo/View/ManageView.swift
+++ b/WatchMeGo/View/ManageView.swift
@@ -57,8 +57,8 @@ struct ManageView: View {
                                 showCompetitionAlert = true
                             }) {
                                 Image(systemName: viewModel.isInCompetition(with: user) ? "flame.fill" : "flame")
-                                    .foregroundColor(viewModel.isInCompetition(with: user) ? DesignSystem.Colors.accent : DesignSystem.Colors.secondary)
-                                    .font(.system(size: viewModel.isInCompetition(with: user) ? 28 : 22))
+                                    .foregroundColor(viewModel.isInCompetition(with: user) ? DesignSystem.Colors.error : DesignSystem.Colors.secondary)
+                                    .font(.system(size: viewModel.isInCompetition(with: user) ? 30 : 24))
                             }
                             .buttonStyle(.plain)
                         }
@@ -117,15 +117,17 @@ struct ManageView: View {
                 .padding(.top, DesignSystem.Spacing.m)
             }
 
+            Spacer()
+
             PrimaryButton(title: "Log out", color: DesignSystem.Colors.error) {
                 viewModel.logout(coordinator: coordinator)
             }
             .padding(.vertical, DesignSystem.Spacing.m)
-
-            Spacer()
         }
         .padding(DesignSystem.Spacing.l)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(DesignSystem.Colors.background)
+        .ignoresSafeArea()
         .task {
             await viewModel.loadData()
         }

--- a/WatchMeGo/View/RegisterView.swift
+++ b/WatchMeGo/View/RegisterView.swift
@@ -51,7 +51,9 @@ struct RegisterView: View {
             }
         }
         .padding(DesignSystem.Spacing.l)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(DesignSystem.Colors.background)
+        .ignoresSafeArea()
     }
 }
 


### PR DESCRIPTION
## Summary
- Use phthalocyanine green as the app's accent color and apply it to buttons
- Group progress bars by user and show competition icon in red or gray
- Make auth screens and manager view fill the screen and pin logout to the bottom

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688f169cac9c83239bf2235483a347c1