### PR TITLE
Revamp manage view layout and progress styling

### DIFF
--- a/WatchMeGo/Extensions/Color+Extensions.swift
+++ b/WatchMeGo/Extensions/Color+Extensions.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+extension Color {
+    func darker(by amount: Double = 0.2) -> Color {
+        let uiColor = UIColor(self)
+        var hue: CGFloat = 0
+        var saturation: CGFloat = 0
+        var brightness: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard uiColor.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha) else { return self }
+        return Color(hue: Double(hue), saturation: Double(saturation), brightness: Double(max(brightness - CGFloat(amount), 0)), opacity: Double(alpha))
+    }
+}

--- a/WatchMeGo/View/Components/ChallengeBannerView.swift
+++ b/WatchMeGo/View/Components/ChallengeBannerView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct ChallengeBannerView: View {
+    let username: String
+
+    var body: some View {
+        Text("\(username), are you ready for challenge?")
+            .font(DesignSystem.Fonts.headline)
+            .foregroundColor(DesignSystem.Colors.background)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, DesignSystem.Spacing.s)
+            .padding(.horizontal, DesignSystem.Spacing.m)
+            .background(
+                Capsule()
+                    .fill(DesignSystem.Colors.accent)
+            )
+            .padding(.top, DesignSystem.Spacing.s)
+    }
+}
+
+#Preview {
+    ChallengeBannerView(username: "Alex")
+        .padding()
+        .background(DesignSystem.Colors.background)
+}

--- a/WatchMeGo/View/Components/CompetitionCouponView.swift
+++ b/WatchMeGo/View/Components/CompetitionCouponView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct CompetitionCouponView: View {
+    let challenger: String
+    let onAccept: () -> Void
+    let onDecline: () -> Void
+    @State private var appear = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.m) {
+            Text("\(challenger) invited you to a competition!")
+                .font(DesignSystem.Fonts.headline)
+                .foregroundColor(DesignSystem.Colors.primary)
+            HStack(spacing: DesignSystem.Spacing.m) {
+                Button("Accept", action: onAccept)
+                    .buttonStyle(.borderedProminent)
+                    .tint(DesignSystem.Colors.accent)
+                Button("Decline", action: onDecline)
+                    .buttonStyle(.bordered)
+                    .tint(DesignSystem.Colors.error)
+            }
+        }
+        .padding(DesignSystem.Spacing.m)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DesignSystem.Colors.surface)
+        .cornerRadius(DesignSystem.Radius.l)
+        .shadow(radius: DesignSystem.Radius.s)
+        .overlay(
+            RoundedRectangle(cornerRadius: DesignSystem.Radius.l)
+                .stroke(style: StrokeStyle(lineWidth: 2, dash: [10]))
+                .foregroundColor(DesignSystem.Colors.accent.opacity(0.5))
+        )
+        .scaleEffect(appear ? 1 : 0.95)
+        .opacity(appear ? 1 : 0)
+        .animation(.spring(response: 0.4, dampingFraction: 0.7), value: appear)
+        .onAppear { appear = true }
+    }
+}
+
+#Preview {
+    CompetitionCouponView(challenger: "Jane", onAccept: {}, onDecline: {})
+        .padding()
+        .background(DesignSystem.Colors.background)
+}

--- a/WatchMeGo/View/Components/FriendsSection.swift
+++ b/WatchMeGo/View/Components/FriendsSection.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct FriendsSection: View {
+    let friends: [AppUser]
+    let isInCompetition: (AppUser) -> Bool
+    let onSelect: (AppUser) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.s) {
+            Text("Friends")
+                .font(DesignSystem.Fonts.headline)
+                .foregroundColor(DesignSystem.Colors.primary)
+            if friends.isEmpty {
+                Text("No friends yet")
+                    .font(DesignSystem.Fonts.footnote)
+                    .foregroundColor(DesignSystem.Colors.secondary)
+            } else {
+                LazyVStack(spacing: DesignSystem.Spacing.s) {
+                    ForEach(friends) { user in
+                        Button {
+                            onSelect(user)
+                        } label: {
+                            HStack {
+                                Text(user.name)
+                                    .font(DesignSystem.Fonts.body)
+                                    .foregroundColor(DesignSystem.Colors.primary)
+                                Spacer()
+                                Image(systemName: isInCompetition(user) ? "flame.fill" : "flame")
+                                    .foregroundColor(isInCompetition(user) ? DesignSystem.Colors.error : DesignSystem.Colors.secondary)
+                                    .font(.system(size: isInCompetition(user) ? 30 : 24))
+                            }
+                            .padding(.vertical, DesignSystem.Spacing.s)
+                            .padding(.horizontal, DesignSystem.Spacing.m)
+                            .background(DesignSystem.Colors.surface)
+                            .cornerRadius(DesignSystem.Radius.m)
+                        }
+                        .buttonStyle(.plain)
+                        .contentShape(Rectangle())
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    FriendsSection(friends: [], isInCompetition: { _ in false }, onSelect: { _ in })
+        .padding()
+        .background(DesignSystem.Colors.background)
+}

--- a/WatchMeGo/View/Components/PendingInvitesSection.swift
+++ b/WatchMeGo/View/Components/PendingInvitesSection.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct PendingInvitesSection: View {
+    let pendingUsers: [AppUser]
+    let onAccept: (AppUser) -> Void
+    let onDecline: (AppUser) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.s) {
+            Text("Pending Invites")
+                .font(DesignSystem.Fonts.headline)
+                .foregroundColor(DesignSystem.Colors.primary)
+            if pendingUsers.isEmpty {
+                Text("No pending invites")
+                    .font(DesignSystem.Fonts.footnote)
+                    .foregroundColor(DesignSystem.Colors.secondary)
+            } else {
+                LazyVStack(spacing: DesignSystem.Spacing.s) {
+                    ForEach(pendingUsers) { user in
+                        HStack {
+                            Text(user.name)
+                                .font(DesignSystem.Fonts.body)
+                                .foregroundColor(DesignSystem.Colors.primary)
+                            Spacer()
+                            Button("Accept") { onAccept(user) }
+                                .buttonStyle(.borderedProminent)
+                                .tint(DesignSystem.Colors.accent)
+                            Button("Decline") { onDecline(user) }
+                                .buttonStyle(.bordered)
+                                .tint(DesignSystem.Colors.error)
+                        }
+                        .padding(.vertical, DesignSystem.Spacing.s)
+                        .padding(.horizontal, DesignSystem.Spacing.m)
+                        .background(DesignSystem.Colors.surface)
+                        .cornerRadius(DesignSystem.Radius.m)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PendingInvitesSection(pendingUsers: [], onAccept: { _ in }, onDecline: { _ in })
+        .padding()
+        .background(DesignSystem.Colors.background)
+}

--- a/WatchMeGo/View/MainView.swift
+++ b/WatchMeGo/View/MainView.swift
@@ -10,14 +10,20 @@ import SwiftUI
 struct MainView: View {
     @Bindable private var viewModel = MainViewModel()
     @Bindable var coordinator: Coordinator
-    
+
     var body: some View {
         VStack(spacing: DesignSystem.Spacing.l) {
             if viewModel.isAuthorized {
                 VStack(alignment: .leading, spacing: DesignSystem.Spacing.m) {
-                    Text("\(coordinator.currentUser?.name ?? "Your") progress")
+                    Text("User Progress")
                         .font(DesignSystem.Fonts.headline)
                         .foregroundColor(DesignSystem.Colors.primary)
+                        .padding(.vertical, DesignSystem.Spacing.xs)
+                        .padding(.horizontal, DesignSystem.Spacing.m)
+                        .background(DesignSystem.Colors.surface)
+                        .cornerRadius(DesignSystem.Radius.s)
+                        .frame(maxWidth: .infinity)
+                        .multilineTextAlignment(.center)
 
                     ProgressBarView(label: "Calories", value: viewModel.calories, goal: 500, color: DesignSystem.Colors.move, iconName: "flame.fill")
                     ProgressBarView(label: "Exercise Minutes", value: viewModel.exerciseMinutes, goal: 80, color: DesignSystem.Colors.exercise, iconName: "figure.run")
@@ -26,13 +32,19 @@ struct MainView: View {
 
                 if let competitive = viewModel.competitiveUser {
                     VStack(alignment: .leading, spacing: DesignSystem.Spacing.m) {
-                        Text("\(competitive.name) progress")
+                        Text("Friend Progress")
                             .font(DesignSystem.Fonts.headline)
                             .foregroundColor(DesignSystem.Colors.primary)
+                            .padding(.vertical, DesignSystem.Spacing.xs)
+                            .padding(.horizontal, DesignSystem.Spacing.m)
+                            .background(DesignSystem.Colors.surface)
+                            .cornerRadius(DesignSystem.Radius.s)
+                            .frame(maxWidth: .infinity)
+                            .multilineTextAlignment(.center)
 
-                        ProgressBarView(label: "Calories", value: competitive.currentProgress?.calories ?? 0, goal: 500, color: DesignSystem.Colors.move, iconName: "flame.fill")
-                        ProgressBarView(label: "Exercise Minutes", value: competitive.currentProgress?.exerciseMinutes ?? 0, goal: 80, color: DesignSystem.Colors.exercise, iconName: "figure.run")
-                        ProgressBarView(label: "Stand Hours", value: competitive.currentProgress?.standHours ?? 0, goal: 10, color: DesignSystem.Colors.stand, iconName: "clock")
+                        ProgressBarView(label: "Calories", value: competitive.currentProgress?.calories ?? 0, goal: 500, color: DesignSystem.Colors.move.darker(), iconName: "flame.fill")
+                        ProgressBarView(label: "Exercise Minutes", value: competitive.currentProgress?.exerciseMinutes ?? 0, goal: 80, color: DesignSystem.Colors.exercise.darker(), iconName: "figure.run")
+                        ProgressBarView(label: "Stand Hours", value: competitive.currentProgress?.standHours ?? 0, goal: 10, color: DesignSystem.Colors.stand.darker(), iconName: "clock")
                     }
                 }
             } else {
@@ -54,5 +66,3 @@ struct MainView: View {
 #Preview {
     MainView(coordinator: Coordinator())
 }
-
-


### PR DESCRIPTION
## Summary
- Add challenge banner, coupon-style competition invite, and dedicated friends and pending invite sections.
- Center user and friend progress labels and darken competitor progress bars for clearer contrast.

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme WatchMeGo -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f1e8237e88323be40e184597a5673