### PR TITLE
Refine friends UI and share error banner

### DIFF
--- a/WatchMeGo/View/Components/CompetitionCouponView.swift
+++ b/WatchMeGo/View/Components/CompetitionCouponView.swift
@@ -7,10 +7,11 @@ struct CompetitionCouponView: View {
     @State private var appear = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.m) {
+        VStack(spacing: DesignSystem.Spacing.m) {
             Text("\(challenger) invited you to a competition!")
                 .font(DesignSystem.Fonts.headline)
                 .foregroundColor(DesignSystem.Colors.primary)
+                .multilineTextAlignment(.center)
             HStack(spacing: DesignSystem.Spacing.m) {
                 Button("Accept", action: onAccept)
                     .buttonStyle(.borderedProminent)
@@ -19,16 +20,22 @@ struct CompetitionCouponView: View {
                     .buttonStyle(.bordered)
                     .tint(DesignSystem.Colors.error)
             }
+            .frame(maxWidth: .infinity)
         }
         .padding(DesignSystem.Spacing.m)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(DesignSystem.Colors.surface)
+        .frame(maxWidth: .infinity)
+        .background(.ultraThinMaterial)
         .cornerRadius(DesignSystem.Radius.l)
         .shadow(radius: DesignSystem.Radius.s)
         .overlay(
             RoundedRectangle(cornerRadius: DesignSystem.Radius.l)
-                .stroke(style: StrokeStyle(lineWidth: 2, dash: [10]))
-                .foregroundColor(DesignSystem.Colors.accent.opacity(0.5))
+                .stroke(
+                    LinearGradient(
+                        colors: [DesignSystem.Colors.accent, DesignSystem.Colors.error],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    ), lineWidth: 3
+                )
         )
         .scaleEffect(appear ? 1 : 0.95)
         .opacity(appear ? 1 : 0)

--- a/WatchMeGo/View/Components/ErrorBannerView.swift
+++ b/WatchMeGo/View/Components/ErrorBannerView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct ErrorBannerView: View {
+    @Bindable private var handler = ErrorHandler.shared
+
+    var body: some View {
+        Group {
+            if handler.showError, let message = handler.errorMessage {
+                VStack {
+                    Spacer()
+                    Text(message)
+                        .font(DesignSystem.Fonts.footnote)
+                        .foregroundColor(DesignSystem.Colors.background)
+                        .padding(.horizontal, DesignSystem.Spacing.l)
+                        .padding(.vertical, DesignSystem.Spacing.s)
+                        .background(DesignSystem.Colors.error.opacity(0.9))
+                        .cornerRadius(DesignSystem.Radius.l)
+                        .shadow(radius: DesignSystem.Radius.s)
+                        .padding(.bottom, DesignSystem.Spacing.l * 2)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .animation(.easeInOut, value: handler.showError)
+            }
+        }
+    }
+}

--- a/WatchMeGo/View/Components/FriendsSection.swift
+++ b/WatchMeGo/View/Components/FriendsSection.swift
@@ -29,9 +29,10 @@ struct FriendsSection: View {
                                     .foregroundColor(isInCompetition(user) ? DesignSystem.Colors.error : DesignSystem.Colors.secondary)
                                     .font(.system(size: isInCompetition(user) ? 30 : 24))
                             }
+                            .frame(maxWidth: .infinity)
                             .padding(.vertical, DesignSystem.Spacing.s)
                             .padding(.horizontal, DesignSystem.Spacing.m)
-                            .background(DesignSystem.Colors.surface)
+                            .background(.ultraThinMaterial)
                             .cornerRadius(DesignSystem.Radius.m)
                         }
                         .buttonStyle(.plain)

--- a/WatchMeGo/View/Components/PendingInvitesSection.swift
+++ b/WatchMeGo/View/Components/PendingInvitesSection.swift
@@ -29,9 +29,10 @@ struct PendingInvitesSection: View {
                                 .buttonStyle(.bordered)
                                 .tint(DesignSystem.Colors.error)
                         }
+                        .frame(maxWidth: .infinity)
                         .padding(.vertical, DesignSystem.Spacing.s)
                         .padding(.horizontal, DesignSystem.Spacing.m)
-                        .background(DesignSystem.Colors.surface)
+                        .background(.ultraThinMaterial)
                         .cornerRadius(DesignSystem.Radius.m)
                     }
                 }

--- a/WatchMeGo/View/Components/PrimaryButton.swift
+++ b/WatchMeGo/View/Components/PrimaryButton.swift
@@ -9,13 +9,14 @@ struct PrimaryButton: View {
         Button(action: action) {
             Text(title)
                 .font(DesignSystem.Fonts.headline)
+                .foregroundColor(DesignSystem.Colors.background)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, DesignSystem.Spacing.s)
+                .background(color)
+                .cornerRadius(DesignSystem.Radius.m)
         }
         .buttonStyle(.plain)
-        .background(color)
-        .foregroundColor(DesignSystem.Colors.background)
-        .cornerRadius(DesignSystem.Radius.m)
+        .contentShape(Rectangle())
         .shadow(radius: DesignSystem.Radius.s, y: DesignSystem.Spacing.xs)
     }
 }

--- a/WatchMeGo/View/LoginView.swift
+++ b/WatchMeGo/View/LoginView.swift
@@ -44,6 +44,7 @@ struct LoginView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(DesignSystem.Colors.background)
         .ignoresSafeArea()
+        .overlay(ErrorBannerView())
     }
 }
 

--- a/WatchMeGo/View/MainTabView.swift
+++ b/WatchMeGo/View/MainTabView.swift
@@ -19,5 +19,6 @@ struct MainTabView: View {
                 .tabItem { Label("Friends", systemImage: "person.2.fill") }
         }
         .tint(DesignSystem.Colors.accent)
+        .overlay(ErrorBannerView())
     }
 }

--- a/WatchMeGo/View/MainView.swift
+++ b/WatchMeGo/View/MainView.swift
@@ -15,7 +15,7 @@ struct MainView: View {
         VStack(spacing: DesignSystem.Spacing.l) {
             if viewModel.isAuthorized {
                 VStack(alignment: .leading, spacing: DesignSystem.Spacing.m) {
-                    Text("User Progress")
+                    Text("\(coordinator.currentUser?.name ?? "User") Progress")
                         .font(DesignSystem.Fonts.headline)
                         .foregroundColor(DesignSystem.Colors.primary)
                         .padding(.vertical, DesignSystem.Spacing.xs)
@@ -32,7 +32,7 @@ struct MainView: View {
 
                 if let competitive = viewModel.competitiveUser {
                     VStack(alignment: .leading, spacing: DesignSystem.Spacing.m) {
-                        Text("Friend Progress")
+                        Text("\(competitive.name) Progress")
                             .font(DesignSystem.Fonts.headline)
                             .foregroundColor(DesignSystem.Colors.primary)
                             .padding(.vertical, DesignSystem.Spacing.xs)
@@ -57,9 +57,7 @@ struct MainView: View {
         }
         .padding(DesignSystem.Spacing.l)
         .background(DesignSystem.Colors.background)
-        .task {
-            await viewModel.loadDataAndSave(for: coordinator.currentUser?.id)
-        }
+        .task { await viewModel.loadDataAndSave(for: coordinator.currentUser?.id) }
     }
 }
 

--- a/WatchMeGo/View/ManageView.swift
+++ b/WatchMeGo/View/ManageView.swift
@@ -37,6 +37,8 @@ struct ManageView: View {
                     .opacity(viewModel.usernameToInvite.isEmpty ? 0.5 : 1)
                 }
 
+                Divider()
+
                 FriendsSection(
                     friends: viewModel.friends,
                     isInCompetition: viewModel.isInCompetition(with:),
@@ -45,6 +47,8 @@ struct ManageView: View {
                         showCompetitionAlert = true
                     }
                 )
+
+                Divider()
 
                 PendingInvitesSection(
                     pendingUsers: viewModel.pendingUsers,
@@ -93,25 +97,5 @@ struct ManageView: View {
             }
             Button("No", role: .cancel) { }
         }
-        .overlay(
-            Group {
-                if ErrorHandler.shared.showError, let msg = ErrorHandler.shared.errorMessage {
-                    VStack {
-                        Spacer()
-                        Text(msg)
-                            .font(DesignSystem.Fonts.footnote)
-                            .foregroundColor(DesignSystem.Colors.background)
-                            .padding(.horizontal, DesignSystem.Spacing.l)
-                            .padding(.vertical, DesignSystem.Spacing.s)
-                            .background(DesignSystem.Colors.error.opacity(0.9))
-                            .cornerRadius(DesignSystem.Radius.l)
-                            .shadow(radius: DesignSystem.Radius.s)
-                            .padding(.bottom, DesignSystem.Spacing.l * 2)
-                            .transition(.move(edge: .bottom).combined(with: .opacity))
-                    }
-                    .animation(.easeInOut, value: ErrorHandler.shared.showError)
-                }
-            }
-        )
     }
 }

--- a/WatchMeGo/View/RegisterView.swift
+++ b/WatchMeGo/View/RegisterView.swift
@@ -54,6 +54,7 @@ struct RegisterView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(DesignSystem.Colors.background)
         .ignoresSafeArea()
+        .overlay(ErrorBannerView())
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace friend and invite capsules with glass-style backgrounds
- Center competition invite banner with gradient border and simplified layout
- Show actual usernames for progress and expose a reusable error banner across the app

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688f25105ed48323af7dbaf19019b110